### PR TITLE
Create annotated, signed tags

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,4 +3,5 @@ current_version = 0.1.1
 files = setup.py
 commit = True
 tag = True
+tag_options = -m "bumpversion v{new_version}"
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -5,6 +5,7 @@ import argparse
 import os
 import warnings
 import re
+import shlex
 import sre_constants
 import subprocess
 from string import Formatter
@@ -121,6 +122,8 @@ def main(args=None):
     parser3.add_argument('--message', '-m', metavar='COMMIT_MSG',
                          help='Commit message',
                          default='Bump version: {current_version} → {new_version}')
+    parser3.add_argument('--tag-options', metavar='TAG_OPTIONS',
+                         dest='tag_options', help='Extra tag options for the tag command, e.g. --sign')
 
     files = []
     if 'files' in defaults:
@@ -185,5 +188,7 @@ def main(args=None):
             subprocess.check_call(
                 ["git", "commit", "-m", args.message.format(**formatargs)])
             if args.tag:
-                subprocess.check_call(
-                    ["git", "tag", "v{new_version}".format(**formatargs)])
+                tag_args = ["git", "tag", "v{new_version}".format(**formatargs)]
+                if args.tag_options:
+                    tag_args.extend(shlex.split(args.tag_options.format(**formatargs)))
+                subprocess.check_call(tag_args)

--- a/tests.py
+++ b/tests.py
@@ -23,6 +23,7 @@ def test_usage_string(tmpdir, capsys):
 usage: py.test [-h] [--config-file FILE] [--bump PART] [--parse REGEX]
                [--serialize FORMAT] [--current-version VERSION] [--dry-run]
                --new-version VERSION [--commit] [--tag] [--message COMMIT_MSG]
+               [--tag-options TAG_OPTIONS]
                file [file ...]
 
 Bumps version strings
@@ -50,6 +51,9 @@ optional arguments:
   --message COMMIT_MSG, -m COMMIT_MSG
                         Commit message (default: Bump version:
                         {current_version} → {new_version})
+  --tag-options TAG_OPTIONS
+                        Extra tag options for the tag command, e.g. --sign
+                        (default: None)
 """.lstrip()
 
 
@@ -219,6 +223,21 @@ def test_git_commit(tmpdir):
     tag_out = subprocess.check_output(["git", "tag"])
 
     assert 'v47.1.3' in tag_out
+
+    describe_out = subprocess.call(["git", "describe"])
+    assert 128 == describe_out
+
+    main(['--current-version', '47.1.3', '--commit', '--tag', '--tag-options', '"-m \\"test v{new_version}-tag\\""', 'VERSION'])
+
+    assert '47.1.4' == tmpdir.join("VERSION").read()
+
+    tag_out = subprocess.check_output(["git", "tag"])
+
+    assert 'v47.1.4' in tag_out
+
+    describe_out = subprocess.check_output(["git", "describe"])
+
+    assert 'v47.1.4' in describe_out
 
 
 def test_bump_version_ENV(tmpdir):


### PR DESCRIPTION
When creating annotated tags (by passing a message into them), you can use `git describe`.

For us, this is wanted behavior (anyone can see exactly what version they're using), but it's a matter of preference.
