### PR TITLE
Add pytest.ini to run unittest without args, ala: py.test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,17 @@
+# ============================================================================
+# PYTEST CONFIGURATION FILE
+# ============================================================================
+# NOTE:
+#   Can also be defined in in tox.ini or pytest.ini file.
+#
+# SEE ALSO:
+#  * http://pytest.org/
+#  * http://pytest.org/customize.html
+#  * http://pytest.org/example/pythoncollection.html#change-naming-conventions
+# ============================================================================
+
+[pytest]
+minversion   = 2.0
+norecursedirs= .git .hg .tox build dist tmp*
+python_files = test*.py  
+


### PR DESCRIPTION
This allows you to run `py.test` without arguments.
It my environment at least, I always needed to use `py.test tests.py` before.
Lazyness wins.
