### PR TITLE
Fix --tag default

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -334,7 +334,7 @@ def main(args=None):
 
     taggroup = parser3.add_mutually_exclusive_group()
 
-    taggroup.add_argument('--tag', action='store_true', dest="tag", default=defaults.get("commit", False),
+    taggroup.add_argument('--tag', action='store_true', dest="tag", default=defaults.get("tag", False),
                           help='Create a tag in version control')
     taggroup.add_argument('--no-tag', action='store_false', dest="tag",
                           help='Do not create a tag in version control', default=argparse.SUPPRESS)

--- a/tests.py
+++ b/tests.py
@@ -331,6 +331,37 @@ def test_commit_and_tag_with_configfile(tmpdir, vcs):
     assert b'v48.1.3' in tag_out
 
 
+@pytest.mark.parametrize(("vcs,config"), [
+    ("git","""[bumpversion]\ncommit = True"""),
+    ("hg", """[bumpversion]\ncommit = True"""),
+    ("git","""[bumpversion]\ncommit = True\ntag = False"""),
+    ("hg", """[bumpversion]\ncommit = True\ntag = False""")
+])
+def test_commit_and_not_tag_with_configfile(tmpdir, vcs, config):
+    tmpdir.chdir()
+
+    tmpdir.join(".bumpversion.cfg").write(config)
+
+    subprocess.check_call([vcs, "init"])
+    tmpdir.join("VERSION").write("48.1.1")
+    subprocess.check_call([vcs, "add", "VERSION"])
+    subprocess.check_call([vcs, "commit", "-m", "initial commit"])
+
+    main(['patch', '--current-version', '48.1.1', 'VERSION'])
+
+    assert '48.1.2' == tmpdir.join("VERSION").read()
+
+    log = subprocess.check_output([vcs, "log", "-p"]).decode("utf-8")
+
+    assert '-48.1.1' in log
+    assert '+48.1.2' in log
+    assert 'Bump version: 48.1.1 → 48.1.2' in log
+
+    tag_out = subprocess.check_output([vcs, {"git": "tag", "hg": "tags"}[vcs]])
+
+    assert b'v48.1.2' not in tag_out
+
+
 @pytest.mark.parametrize(("vcs"), [("git"), ("hg")])
 def test_commit_explicitly_false(tmpdir, vcs):
     tmpdir.chdir()


### PR DESCRIPTION
The tag option was using the wrong default: "commit" instead of "tag". This
lead to the situation that you could not bump a version and commit it without
tagging it.
