### PR TITLE
Fixed bug related to dirty workdir

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -77,7 +77,7 @@ class Git(object):
 
         info = {}
 
-        if describe_out[-1] is "dirty":
+        if describe_out[-1].strip() == "dirty":
             info["dirty"] = True
             describe_out.pop()
 


### PR DESCRIPTION
- `describe_out[-1]` may contain a newline, therefore the `strip()` is necessary.
- `is` does identity comparison. You need `==` there.
