### PR TITLE
Add a -v / --version argument to the parser argument

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -274,11 +274,13 @@ def main(original_args=None):
       sys.argv[1:] if original_args is None else original_args
     )
 
-    parser1 = argparse.ArgumentParser(add_help=False)
+    parser1 = argparse.ArgumentParser(add_help=False, prog='bumpversion')
 
     parser1.add_argument(
         '--config-file', default='.bumpversion.cfg', metavar='FILE',
         help='Config file to read most of the variables from', required=False)
+    parser1.add_argument('-v', '--version', action='version',
+                         version="%s %s" % (parser1.prog, __VERSION__))
 
     known_args, remaining_argv = parser1.parse_known_args(args)
 

--- a/tests.py
+++ b/tests.py
@@ -26,10 +26,10 @@ xfail_if_no_hg = pytest.mark.xfail(
 )
 
 EXPECTED_USAGE = ("""
-usage: py.test [-h] [--config-file FILE] [--parse REGEX] [--serialize FORMAT]
-               [--current-version VERSION] [--dry-run] --new-version VERSION
-               [--commit | --no-commit] [--tag | --no-tag]
-               [--tag-name TAG_NAME] [--message COMMIT_MSG]
+usage: py.test [-h] [--config-file FILE] [-v] [--parse REGEX]
+               [--serialize FORMAT] [--current-version VERSION] [--dry-run]
+               --new-version VERSION [--commit | --no-commit]
+               [--tag | --no-tag] [--tag-name TAG_NAME] [--message COMMIT_MSG]
                part [file [file ...]]
 
 %s
@@ -42,6 +42,7 @@ optional arguments:
   -h, --help            show this help message and exit
   --config-file FILE    Config file to read most of the variables from
                         (default: .bumpversion.cfg)
+  -v, --version         show program's version number and exit
   --parse REGEX         Regex parsing the version string (default:
                         (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+))
   --serialize FORMAT    How to format what is parsed back to a version
@@ -91,7 +92,7 @@ def test_regression_help_in_workdir(tmpdir, capsys, vcs):
     assert err == ""
 
     if vcs == "git":
-        assert "usage: py.test [-h] [--config-file FILE] [--parse REGEX] [--serialize FORMAT]" in out
+        assert "usage: py.test [-h] [--config-file FILE] [-v] [--parse REGEX]" in out
         assert "Version that needs to be updated (default: 1.7.2013)" in out
         assert "[--new-version VERSION]" in out
     else:


### PR DESCRIPTION
The output is the following:

``` bash
$ bumversion --version
bumpversion 0.3.8
```

The tests checking the output of the usage dialogs have been
updated.
Signed-off-by: Balthazar Rouberol balthazar.rouberol@mapado.com
