### PR TITLE
Save the files in binary mode to avoid mutating newlines. Fixes #44

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -653,8 +653,8 @@ def main(original_args=None):
         ))))
 
         if not args.dry_run:
-            with io.open(path, 'wt', encoding='utf-8') as f:
-                f.write(after)
+            with io.open(path, 'wb') as f:
+                f.write(after.encode('utf-8'))
 
     commit_files = files
 


### PR DESCRIPTION
Consider this pull request which addresses issue #44 by saving files the same way they're opened.
