### PR TITLE
actually always test python27

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ commands=
   py.test tests.py
 
 [testenv:py27-configparser]
+basepython= python2.7
 deps=
   pytest
   mock


### PR DESCRIPTION
Some systems use python3 as default python
