### PR TITLE
Fix: _labels_for_format was returning None labels

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -443,7 +443,11 @@ class VersionConfig(object):
         self.replace = replace
 
     def _labels_for_format(self, serialize_format):
-        return (label for _, label, _, _ in Formatter().parse(serialize_format))
+        return (
+            label
+            for _, label, _, _ in Formatter().parse(serialize_format)
+            if label
+        )
 
     def order(self):
         # currently, order depends on the first given serialization format


### PR DESCRIPTION
If there were any characters after the last label in the serialize string, `_labels_for_format` would return an extra `None` label.

Example config file:

``` cfg
[bumpversion:file:bower.json]
parse = "version": "(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)"
serialize = "version": "{major}.{minor}.{patch}"
```
