### PR TITLE
Windows support

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -70,7 +70,7 @@ class BaseVCS(object):
         f.write(message.encode('utf-8'))
         f.close()
         subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=dict(
-            list(os.environ.items()) + [('HGENCODING', 'utf-8')]
+            list(os.environ.items()) + [(b'HGENCODING', b'utf-8')]
         ))
         os.unlink(f.name)
 

--- a/tests.py
+++ b/tests.py
@@ -27,7 +27,7 @@ SUBPROCESS_ENV = dict(
                    reason="Windows does not allow Unicode in environment.")
 def test_unicode_env():
     retcode = subprocess.call("exit 42", shell=True,
-                              env={unicode("a"): unicode("b")})
+                              env={"a": "b"})
     assert retcode == 42
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)

--- a/tests.py
+++ b/tests.py
@@ -20,8 +20,15 @@ import bumpversion
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException
 
 SUBPROCESS_ENV = dict(
-    list(environ.items()) + [('HGENCODING', 'utf-8')]
+    list(environ.items()) + [(b'HGENCODING', b'utf-8')]
 )
+
+@pytest.mark.xfail(sys.platform == 'win32',
+                   reason="Windows does not allow Unicode in environment.")
+def test_unicode_env():
+    retcode = subprocess.call("exit 42", shell=True,
+                              env={unicode("a"): unicode("b")})
+    assert retcode == 42
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)
 check_call = partial(subprocess.check_call, env=SUBPROCESS_ENV)


### PR DESCRIPTION
Bumpversion fails on windows because Unicode values are entered into the
environment (due to `from __future__ import unicode_literals`).

I cannot reproduce the problem on linux.

This is the error I'm seeing on windows before this change:

    ____ ERROR collecting tests.py _______
    tests.py:36: in <module>
      call(["git", "--help"], shell=True) != 1,
    c:\python27\Lib\subprocess.py:493: in call
      return Popen(*popenargs, **kwargs).wait()
    c:\python27\Lib\subprocess.py:679: in __init__
      errread, errwrite)
    c:\python27\Lib\subprocess.py:896: in _execute_child
      startupinfo)
    E   TypeError: environment can only contain strings
