### PR TITLE
Force ascii encoding when adding env variables

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -70,7 +70,7 @@ class BaseVCS(object):
         f.write(message.encode('utf-8'))
         f.close()
         subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=dict(
-            list(os.environ.items()) + [('HGENCODING', 'utf-8')]
+            list(os.environ.items()) + [('HGENCODING'.encode('ascii'), 'utf-8'.encode('ascii'))]
         ))
         os.unlink(f.name)
 

--- a/tests.py
+++ b/tests.py
@@ -20,7 +20,7 @@ import bumpversion
 from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException
 
 SUBPROCESS_ENV = dict(
-    list(environ.items()) + [('HGENCODING', 'utf-8')]
+    list(environ.items()) + [('HGENCODING'.encode('ascii'), 'utf-8'.encode('ascii'))]
 )
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)


### PR DESCRIPTION
Windows doesn't like unicode strings in the environment, causing commits to
fail with the error TypeError: environment can only contain strings. Fixes #67 
