### PR TITLE
Fix line ending issue on windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ include/
 lib/
 .Python
 bumpversion.egg-info/
+*.pyc

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -270,8 +270,8 @@ class ConfiguredFile(object):
             ))
 
         if not dry_run:
-            with io.open(self.path, 'wt', encoding='utf-8') as f:
-                f.write(file_content_after)
+            with io.open(self.path, 'wb') as f:
+                f.write(file_content_after.encode('utf-8'))
 
     def __str__(self):
         return self.path


### PR DESCRIPTION
Fixes:
>       assert 'My birthday: 3.5.98\nCurrent version: 3.6.0' ==
tmpdir.join("file89").read()
E       assert 'My birthday:...ersion: 3.6.0' == 'My birthday:
...ersion: 3.6.0'
E         - My birthday: 3.5.98
E         + My birthday: 3.5.98\r
E         ?                    ++
E           Current version: 3.6.0