### PR TITLE
Avoid reliance on line-breaks in usage string test

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Screencast
 ==========
 
 .. image:: https://dl.dropboxusercontent.com/u/8735936/Screen%20Shot%202013-04-12%20at%202.43.46%20PM.png
-  :target: http://goo.gl/gljhM
+  :target: https://asciinema.org/a/3828
 
 Installation
 ============

--- a/tests.py
+++ b/tests.py
@@ -63,12 +63,24 @@ def _mock_calls_to_string(called_mock):
 
 
 EXPECTED_OPTIONS = """
-[-h] [--config-file FILE] [--verbose] [--list] [--allow-dirty]
-[--parse REGEX] [--serialize FORMAT] [--search SEARCH]
-[--replace REPLACE] [--current-version VERSION] [--dry-run]
---new-version VERSION [--commit | --no-commit]
-[--tag | --no-tag] [--tag-name TAG_NAME] [--message COMMIT_MSG]
-part [file [file ...]]
+[-h]
+[--config-file FILE]
+[--verbose]
+[--list]
+[--allow-dirty]
+[--parse REGEX]
+[--serialize FORMAT]
+[--search SEARCH]
+[--replace REPLACE]
+[--current-version VERSION]
+[--dry-run]
+--new-version VERSION
+[--commit | --no-commit]
+[--tag | --no-tag]
+[--tag-name TAG_NAME]
+[--message COMMIT_MSG]
+part
+[file [file ...]]
 """.strip().splitlines()
 
 EXPECTED_USAGE = ("""


### PR DESCRIPTION
Fixes:
>           assert option_line in out, "Usage string is missing
{0}".format(option_line)
E           AssertionError: Usage string is missing [-h] [--config-file
FILE] [--verbose] [--list] [--allow-dirty]
\x1b[1m\x1b[31mE           assert '[-h] [--config-file FILE] [--verbose]
[--list] [--allow-dirty]' in 'usage: py.test-script.py [-h]
[--config-file FILE] [--verbose] [--list]\\n
[--allow-dirty] [--p...                    Commit message (default: Bump
version:\\n                        {current_version} \u2192
{new_version})\\n'\x1b[0m

w:\github\bumpversion\tests.py:126: AssertionError
!!!!!!!!!!!!!!!!!!! Interrupted: stopping after 1 failures
!!!!!!!!!!!!!!!!!!!!