### PR TITLE
Updated trove classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,14 @@ setup(
         ]
     },
     classifiers=(
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.2',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',


### PR DESCRIPTION
As bumpversion has reached version 0.5 it's ok in my opinion to replace alpha
with beta.