### PR TITLE
Fix new version bug

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -880,8 +880,8 @@ def main(original_args=None):
 
     if args.dry_run:
         logger.info("Dry run active, won't touch any files.")
-
-    if not new_version:
+    
+    if args.new_version:
         new_version = vc.parse(args.new_version)
 
     logger.info("New version will be '{}'".format(args.new_version))

--- a/tests.py
+++ b/tests.py
@@ -1775,3 +1775,25 @@ def test_regression_dont_touch_capitalization_of_keys_in_config(tmpdir, capsys):
     DJANGO_SETTINGS = Value
     """).strip() == tmpdir.join("setup.cfg").read().strip()
 
+def test_regression_new_version_cli_in_files(tmpdir, capsys):
+    '''
+    Reported here: https://github.com/peritus/bumpversion/issues/60
+    '''
+    tmpdir.chdir()
+    tmpdir.join("myp___init__.py").write("__version__ = '0.7.2'")
+    tmpdir.chdir()
+
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        current_version = 0.7.2
+        files = myp___init__.py
+        message = v{new_version}
+        tag_name = {new_version}
+        tag = true
+        commit = true
+        """).strip())
+
+    main("patch --allow-dirty --verbose --new-version 0.9.3".split(" "))
+
+    assert "__version__ = '0.9.3'" == tmpdir.join("myp___init__.py").read()
+    assert "current_version = 0.9.3" in tmpdir.join(".bumpversion.cfg").read()

--- a/tests.py
+++ b/tests.py
@@ -894,6 +894,8 @@ def test_log_no_config_file_info_message(tmpdir, capsys):
         info|Parsed the following values: major=1, minor=0, patch=0|
         info|Attempting to increment part 'patch'|
         info|Values are now: major=1, minor=0, patch=1|
+        info|Parsing version '1.0.1' using regexp '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'|
+        info|Parsed the following values: major=1, minor=0, patch=1|
         info|New version will be '1.0.1'|
         info|Asserting files blargh.txt contain the version string:|
         info|Found '1.0.0' in blargh.txt at line 0: 1.0.0|
@@ -984,6 +986,8 @@ def test_complex_info_logging(tmpdir, capsys):
         info|Parsed the following values: major=0, minor=4, patch=0|
         info|Attempting to increment part 'patch'|
         info|Values are now: major=0, minor=4, patch=1|
+        info|Parsing version '0.4.1' using regexp '(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?'|
+        info|Parsed the following values: major=0, minor=4, patch=1|
         info|New version will be '0.4.1'|
         info|Asserting files fileE contain the version string:|
         info|Found '0.4' in fileE at line 0: 0.4|
@@ -1051,6 +1055,8 @@ def test_subjunctive_dry_run_logging(tmpdir, vcs):
         info|Attempting to increment part 'patch'|
         info|Values are now: major=0, minor=8, patch=1|
         info|Dry run active, won't touch any files.|
+        info|Parsing version '0.8.1' using regexp '(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?'|
+        info|Parsed the following values: major=0, minor=8, patch=1|
         info|New version will be '0.8.1'|
         info|Asserting files dont_touch_me.txt contain the version string:|
         info|Found '0.8' in dont_touch_me.txt at line 0: 0.8|
@@ -1119,6 +1125,8 @@ def test_log_commitmessage_if_no_commit_tag_but_usable_vcs(tmpdir, vcs):
         info|Parsed the following values: major=0, minor=3, patch=3|
         info|Attempting to increment part 'patch'|
         info|Values are now: major=0, minor=3, patch=4|
+        info|Parsing version '0.3.4' using regexp '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'|
+        info|Parsed the following values: major=0, minor=3, patch=4|
         info|New version will be '0.3.4'|
         info|Asserting files please_touch_me.txt contain the version string:|
         info|Found '0.3.3' in please_touch_me.txt at line 0: 0.3.3|
@@ -1247,7 +1255,7 @@ def test_optional_value_from_documentation(tmpdir):
     tmpdir.join(".bumpversion.cfg").write(dedent("""
       [bumpversion]
       current_version = 1.alpha
-      parse = (?P<num>\d+)\.(?P<release>.*)
+      parse = (?P<num>\d+)(\.(?P<release>.*))?(\.)?
       serialize =
         {num}.{release}
         {num}
@@ -1456,6 +1464,8 @@ def test_search_replace_to_avoid_updating_unconcerned_lines(tmpdir, capsys):
         info|Parsed the following values: major=1, minor=5, patch=6|
         info|Attempting to increment part 'minor'|
         info|Values are now: major=1, minor=6, patch=0|
+        info|Parsing version '1.6.0' using regexp '(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)'|
+        info|Parsed the following values: major=1, minor=6, patch=0|
         info|New version will be '1.6.0'|
         info|Asserting files requirements.txt contain the version string:|
         info|Found 'MyProject==1.5.6' in requirements.txt at line 1: MyProject==1.5.6|


### PR DESCRIPTION
This fixes #60, by assuming that if you pass in a `--new-version` flag, that's really the version you want.

