### PR TITLE
Fixed Travis CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py34, py33, py32, py27, py27-configparser, pypy
 
 [testenv]
+passenv = HOME
 deps=
   pytest
   mock


### PR DESCRIPTION
Added HOME to the list of environment variables passed by Tox to the test environment (see https://testrun.org/tox/latest/example/basic.html#passing-down-environment-variables). This is mandatory because Git wants to access the variables in ~/.gitconfig