### PR TITLE
--list-fields option added

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -330,6 +330,16 @@ Additionally, the following options are available:
     current_version=0.0.18
     new_version=0.0.19
 
+``--list-fields``
+  List values of the given fields (comma separated) to stdout. The fields are
+  those listed by --list.
+
+  Example ::
+
+    $ bumpversion --list-fields=current_version,new_version minor
+    0.0.18
+    0.0.19
+
 ``-h, --help``
   Print help and exit
 


### PR DESCRIPTION
I added a small option to output just the value of some fields.
This is useful when, for example, using git flow. You want to know in advance the new release number to create le release branch, and with just --list you need to grep and sed the number. Not a complex job, but with this option you just issue "bumpversion --list-fields new_version <part>" and get the value.