### PR TITLE
add support for post processing with --post-hook

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -310,6 +310,22 @@ Options
 Most of the configuration values above can also be given as an option.
 Additionally, the following options are available:
 
+``--post-hook POST_HOOK``
+  Python hook function to run on each block of text being replaced. The hook
+  function is called once for each bumped file with arguments:
+
+  - ``s`` - the text of the file after version replacement
+  - ``current_version`` - the current version
+  - ``new_version`` - the new version
+
+  The return value of the hook is used as the new text of the file. The hook
+  is called after version replacement but before other actions like version
+  control commits.
+
+  Example::
+    def my_expand_newlines_hook(s, current_version, new_version):
+        return s.replace('-newline-', '\n')
+
 ``--dry-run, -n``
   Don't touch any files, just pretend. Best used with ``--verbose``.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,6 +107,9 @@ optional arguments:
                         {current_version})
   --replace REPLACE     Template for complete string to replace (default:
                         {new_version})
+  --post-hook POST_HOOK
+                        Hook function to run on text after normal replacement
+                        (default: None)
   --current-version VERSION
                         Version that needs to be updated (default: None)
   --dry-run, -n         Don't write any files, just pretend. (default: False)
@@ -204,6 +207,17 @@ def test_simple_replacement(tmpdir):
     tmpdir.chdir()
     main(shlex_split("patch --current-version 1.2.0 --new-version 1.2.1 VERSION"))
     assert "1.2.1" == tmpdir.join("VERSION").read()
+
+
+def test_post_hook(tmpdir):
+    tmpdir.join("VERSION").write("v1.2.0")
+    tmpdir.chdir()
+    tmpdir.join("foo.py").write("""def hook(s, current_version, new_version):
+        return 'hook-{}-{}-{}'.format(s, current_version, new_version)
+    """)
+    sys.path.append(str(tmpdir))
+    main(shlex_split("patch --post-hook foo.hook --current-version 1.2.0 --new-version 1.2.1 VERSION"))
+    assert "hook-v1.2.1-1.2.0-1.2.1" == tmpdir.join("VERSION").read()
 
 
 def test_simple_replacement_in_utf8_file(tmpdir):


### PR DESCRIPTION
_Thank you so much for bumpversion. It's the link in the release process chain that I have been missing and wanting for so long_

I have two use cases that I started to solve with `sed` and multiple `bumpversion` invocations before deciding there had to be a better way.
#### [1] replacement text with leading '#' character

This came up managing a changelog using the same pattern that bumpversion uses: insert a line for the new version when bumping. Works great with rST, but with Markdown things get interesting. I wanted to write:

```
[bumpversion:file:CHANGELOG.md]
search = ## [Unreleased][unreleased]
replace = ## [Unreleased][unreleased]
    ## [{new_version}] - [{now:%Y-%m-%d}]
```

but of course `configparser` treats that last line as a comment. Could add a marker and use `sed` or figure out another way to write the Markdown (dash underlines for level 2 instead of ## could work here). Both felt bad to me.
### [2] removal of line

I ran into this copying the flow that bumpversion releases themselves use for the CHANGELOG. After `bumpversion release` the CHANGELOG is in good shape. After the `bumpversion patch` to start the unreleased dev section there is this pesky extra line. I was wondering how bumpversion dealt with it and then I saw the "grooming changelog" commits...

What I wanted was a chance to do extra stuff to the replaced text of each file so I added a `--post-hook` argument. With it the above use cases are solved with a config snippet like:

```
[bumpversion:file:CHANGELOG.md]
search = ## [Unreleased][unreleased]
replace = ## [Unreleased][unreleased]
    <<>>## [{new_version}] - [{now:%Y-%m-%d}]
```

and this hook:

``` python
import re

def hook(s, current_version, new_version):
    s = s.replace('<<>>', '')

    if (new_version.endswith('-dev')):
        pat = re.compile('## \[({})\]'.format(new_version))

        def dev_line(line):
            m = re.match(pat, line)
            if m:
                return m.group(1) == new_version

        lines = [line for line in s.splitlines() if not dev_line(line)]
        s = '\n'.join(lines)

    return s
```

I'd appreciate any feedback or suggestions, whether or not this PR is a good fit for the project.
