### PR TITLE
Allow package to be invoked as `python -m bumpversion`

### DIFF
--- a/bumpversion/__main__.py
+++ b/bumpversion/__main__.py
@@ -1,0 +1,1 @@
+__import__('bumpversion').main()


### PR DESCRIPTION
PEP 338 defines a spec allowing modules and packages to be executed without an entry script. This simple module makes `python -m bumpversion` execute bumpversion.