### PR TITLE
allow multiple config sections per file

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -718,7 +718,7 @@ def main(original_args=None):
 
         for section_name in config.sections():
 
-            section_name_match = re.compile("^bumpversion:(file|part):([^:]+)").match(section_name)
+            section_name_match = re.compile("^bumpversion:(file|part).*?:(.+)").match(section_name)
 
             if not section_name_match:
                 continue

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -718,7 +718,7 @@ def main(original_args=None):
 
         for section_name in config.sections():
 
-            section_name_match = re.compile("^bumpversion:(file|part):(.+)").match(section_name)
+            section_name_match = re.compile("^bumpversion:(file|part):([^:]+)").match(section_name)
 
             if not section_name_match:
                 continue


### PR DESCRIPTION
Assuming it's ok to disallow "`:`" in filenames, this change would allow config section names for files to have trailing characters that are not interpreted as part of the filename, but that make the key unique in terms of config parsing, e.g.:

```
[bumpversion:file:myfile:0]
search = some context for {current_version}

[bumpversion:file:myfile:1]
search = another context for {current_version}
```

In our application, we have two different sets of parse/serialize/search/replace configs that need to be run on the same files (e.g. some versions appear as "major.minor.patch" while others appear as "major_minor_patch", and with different surrounding search context). This one minor change to bumpversion would make such a scenario possible by allowing multiple configuration sections and thus multiple independent search/replace passes per file.
