### PR TITLE
Added functions to part configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,42 +177,49 @@ For advanced versioning schemes, non-numeric parts may be desirable (e.g. to
 identify `alpha or beta versions
 <http://en.wikipedia.org/wiki/Software_release_life_cycle#Stages_of_development>`_,
 to indicate the stage of development, the flavor of the software package or
-a release name). To do so, you can use a ``[bumpversion:part:…]`` section
+a release name). To do so, you can use a ``[bumpversion:part:<part_name>]`` section
 containing the part's name (e.g. a part named ``release_name`` is configured in
 a section called ``[bumpversion:part:release_name]``.
 
 The following options are valid inside a part configuration:
 
-``values =``
+``function =``
   **default**: numeric (i.e. ``0``, ``1``, ``2``, …)
 
-  Explicit list of all values that will be iterated when bumping that specific
-  part.
+  This sets the function used to manage the part and the strategy to increment it.
+  Every function has its own configuration parameters which are specified just after
+  the function like ``<parameter> = <value>``. Every function has an optional value,
+  which is a value that can be omitted when representing the version (e.g. in a two-parts
+  version ``v4`` is the same as ``v4.0``. In this case the second part has an optional
+  value of ``0``). In bumpversion parts lingo 'optional' is the same as 'default'.
+
+  The list of currently available functions is: ``numeric``, ``values``, ``date``.
+  
+  ``numeric`` - This considers the part a single integer with an increment of 1.
+  You may specify the initial value through the ``first_value`` parameter, otherwise
+  it is ``0``. The optional value is ``first_value``.
+
+  This function also supports alphanumeric parts, altering just the numeric section
+  (e.g. 'r3' --> 'r4'). Only the first numeric group found in the part is considered
+  (e.g. 'r3-001' --> 'r4-001').
 
   Example::
 
-    [bumpversion:part:release_name]
-    values =
-      witty-warthog
-      ridiculous-rat
-      marvelous-mantis
+    [bumpversion:part:major]
+    function = numeric
+    first_value = rel1
 
-``optional_value =``
-  **default**: The first entry in ``values =``.
-
-  If the value of the part matches this value it is considered optional, i.e.
-  it's representation in a ``--serialize`` possibility is not required.
+  ``values`` - This uses as values of the part the element of a list that must be
+  specified through the ``values`` parameter. The optional value of the part is the
+  first value of the list. If you try to bump a part which has already the maximum
+  value of the list you get a ValueError exception. You may specify both the ``first_value``
+  and the ``optional_value``. If not given they are both equal to the first value of
+  the list. If specified, each of them shall be included in the given list of values.
 
   Example::
 
-    [bumpversion]
-    current_version = 1.alpha
-    parse = (?P<num>\d+)\.(?P<release>.*)
-    serialize =
-      {num}.{release}
-      {num}
-
-    [bumpversion:part:release]
+    [bumpversion:part:status]
+    function = values
     optional_value = gamma
     values =
       alpha
@@ -223,10 +230,26 @@ The following options are valid inside a part configuration:
   ``bumpversion release`` again would bump ``1.beta`` to ``1``, because
   `release` being ``gamma`` is configured optional.
 
-``first_value =``
-  **default**: The first entry in ``values =``.
+    [bumpversion:part:release_name]
+    function = values
+    values =
+      witty-warthog
+      ridiculous-rat
+      marvelous-mantis
 
-  When the part is reset, the value will be set to the value specified here.
+  ``date`` - This function returns the current date formatted by default as ``%Y%m%d%H%M%S``
+  according to the ``strftime`` and ``strptime`` functions language (see
+  https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+    or https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).
+
+  You may specify an alternative formatting string through the ``format`` parameter.
+
+  Example::
+
+    [bumpversion:part:release_name]
+    function = date
+    format = %Y%m%d
+
 
 File specific configuration
 ---------------------------

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -28,7 +28,7 @@ from tempfile import NamedTemporaryFile
 import sys
 import codecs
 
-from bumpversion.version_part import VersionPart, NumericVersionPartConfiguration, ConfiguredVersionPartConfiguration
+from bumpversion.version_part import VersionPart, PartConfiguration
 
 if sys.version_info[0] == 2:
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
@@ -340,7 +340,7 @@ class VersionConfig(object):
     Holds a complete representation of a version string
     """
 
-    def __init__(self, parse, serialize, search, replace, part_configs=None):
+    def __init__(self, parse, serialize, search, replace, part_configs={}):
 
         try:
             self.parse_regex = re.compile(parse, re.VERBOSE)
@@ -349,9 +349,6 @@ class VersionConfig(object):
             raise e
 
         self.serialize_formats = serialize
-
-        if not part_configs:
-            part_configs = {}
 
         self.part_configs = part_configs
         self.search = search
@@ -647,13 +644,13 @@ def main(original_args=None):
 
             if section_prefix == "part":
 
-                ThisVersionPartConfiguration = NumericVersionPartConfiguration
-
                 if 'values' in section_config:
-                    section_config['values'] = list(filter(None, (x.strip() for x in section_config['values'].splitlines())))
-                    ThisVersionPartConfiguration = ConfiguredVersionPartConfiguration
+                    if not 'function' in section_config:
+                        warnings.warn("Using a values-based version part without specifying 'function = values' will be deprecated.", PendingDeprecationWarning)
 
-                part_configs[section_value] = ThisVersionPartConfiguration(**section_config)
+                    section_config['values'] = list(filter(None, (x.strip() for x in section_config['values'].splitlines())))
+
+                part_configs[section_value] = PartConfiguration(**section_config)
 
             elif section_prefix == "file":
 

--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -340,7 +340,7 @@ class VersionConfig(object):
     Holds a complete representation of a version string
     """
 
-    def __init__(self, parse, serialize, search, replace, part_configs={}):
+    def __init__(self, parse, serialize, search, replace, part_configs=None):
 
         try:
             self.parse_regex = re.compile(parse, re.VERBOSE)
@@ -349,7 +349,10 @@ class VersionConfig(object):
             raise e
 
         self.serialize_formats = serialize
-
+        
+        if not part_configs:
+            part_configs = {}
+            
         self.part_configs = part_configs
         self.search = search
         self.replace = replace

--- a/bumpversion/functions.py
+++ b/bumpversion/functions.py
@@ -87,3 +87,29 @@ class ValuesFunction(object):
             raise ValueError(
                 "The part has already the maximum value among {} and cannot be bumped.".format(self._values))
 
+class DateFunction(object):
+
+    """
+    This is a class that provides a date based engine for version parts.
+    It is initialized with a format according to the strftime() and strptime()
+    rules (see https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+    or https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior).
+
+    The first value and the default value of this field are equal to the Unix
+    Epoch (00:00:00 1st January 1970) but given the meaning of the data should
+    be never used (either that or you are Emmett Brown).
+
+    When bumped, this field returns always the current date and time formatted
+    with the given format.
+    """
+
+    def __init__(self, format='%Y%m%d%H%M%S'):
+        self._format = format
+
+        unix_epoch = datetime.datetime.strptime(
+            '19700101000000', '%Y%m%d%H%M%S')
+        self.first_value = unix_epoch.strftime(self._format)
+        self.optional_value = self.first_value
+
+    def bump(self, value=None):
+        return datetime.datetime.now().strftime(self._format)

--- a/bumpversion/version_part.py
+++ b/bumpversion/version_part.py
@@ -1,9 +1,31 @@
-from bumpversion.functions import NumericFunction, ValuesFunction
+from bumpversion.functions import NumericFunction, ValuesFunction, DateFunction
 
 class PartConfiguration(object):
     function_cls = NumericFunction
 
     def __init__(self, *args, **kwds):
+
+        functions_dict = {
+            'numeric': NumericFunction,
+            'values': ValuesFunction,
+            'date': DateFunction
+        }
+
+        # Get the function to be used, if set
+        try:
+            function = kwds.pop('function')
+
+            try:
+                self.function_cls = functions_dict[function]
+            except KeyError:
+                raise ValueError("Function '{}' is not supported".format(function))
+        except KeyError:
+            if 'values' in kwds:
+                self.function_cls = ValuesFunction
+            else:
+                # This is the default function
+                self.function_cls = NumericFunction
+
         self.function = self.function_cls(*args, **kwds)
 
     @property
@@ -18,14 +40,6 @@ class PartConfiguration(object):
         return self.function.bump(value)
 
 
-class ConfiguredVersionPartConfiguration(PartConfiguration):
-    function_cls = ValuesFunction
-
-
-class NumericVersionPartConfiguration(PartConfiguration):
-    function_cls = NumericFunction
-
-
 class VersionPart(object):
 
     """
@@ -37,9 +51,9 @@ class VersionPart(object):
         self._value = value
 
         if config is None:
-            config = NumericVersionPartConfiguration()
-
-        self.config = config
+            self.config = PartConfiguration()
+        else:
+            self.config = config
 
     @property
     def value(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import pytest
 import sys
 import logging
 import mock
+from datetime import datetime
 
 import argparse
 import subprocess
@@ -1219,33 +1220,134 @@ def test_no_list_no_stdout(tmpdir, vcs):
 
     assert out == ""
 
-def test_bump_non_numeric_parts(tmpdir, capsys):
-    tmpdir.join("with_prereleases.txt").write("1.5.dev")
+def test_bump_explicit_numeric_part(tmpdir, capsys):
+    tmpdir.join("explicit_numeric.txt").write("1.rel1")
     tmpdir.chdir()
 
     tmpdir.join(".bumpversion.cfg").write(dedent("""
         [bumpversion]
-        files = with_prereleases.txt
-        current_version = 1.5.dev
-        parse = (?P<major>\d+)\.(?P<minor>\d+)(\.(?P<release>[a-z]+))?
-        serialize =
-          {major}.{minor}.{release}
-          {major}.{minor}
+        files = explicit_numeric.txt
+        current_version = 1.rel1
+        parse = (?P<major>\d+)\.(?P<minor>[a-z0-9]+)
+        serialize = {major}.{minor}
 
         [bumpversion:part:release]
-        optional_value = gamma
-        values =
-          dev
-          gamma
+        function = numeric
         """).strip())
-
-    main(['release', '--verbose'])
-
-    assert '1.5' == tmpdir.join("with_prereleases.txt").read()
 
     main(['minor', '--verbose'])
 
-    assert '1.6.dev' == tmpdir.join("with_prereleases.txt").read()
+    assert '1.rel2' == tmpdir.join("explicit_numeric.txt").read()
+
+def test_bump_explicit_numeric_part_with_first_value(tmpdir, capsys):
+    tmpdir.join("explicit_numeric_with_first_value.txt").write("1.rel1")
+    tmpdir.chdir()
+
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        files = explicit_numeric_with_first_value.txt
+        current_version = 1.rel1
+        parse = (?P<major>\d+)\.(?P<minor>[a-z0-9]+)
+        serialize = {major}.{minor}
+
+        [bumpversion:part:minor]
+        function = numeric
+        first_value = rel1
+        """).strip())
+
+    main(['major', '--verbose'])
+
+    assert '2.rel1' == tmpdir.join("explicit_numeric_with_first_value.txt").read()
+
+def test_bump_values_part(tmpdir, capsys):
+    tmpdir.join("values.txt").write("1.alpha")
+    tmpdir.chdir()
+
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        files = values.txt
+        current_version = 1.alpha
+        parse = (?P<major>\d+)\.(?P<minor>[a-z]+)
+        serialize = {major}.{minor}
+
+        [bumpversion:part:minor]
+        function = values
+        values = 
+            alpha
+            beta
+            stable
+        """).strip())
+
+    main(['minor', '--verbose'])
+
+    assert '1.beta' == tmpdir.join("values.txt").read()
+
+    main(['major', '--verbose'])
+
+    assert '2.alpha' == tmpdir.join("values.txt").read()
+
+    with pytest.raises(ValueError):
+        main(['minor', '--verbose'])
+        main(['minor', '--verbose'])
+        main(['minor', '--verbose'])
+
+def test_bump_values_part_without_values_function(tmpdir, capsys):
+    # This test ensures backward compatibility with the previous
+    # configuration schema
+
+    tmpdir.join("values.txt").write("1.alpha")
+    tmpdir.chdir()
+
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        files = values.txt
+        current_version = 1.alpha
+        parse = (?P<major>\d+)\.(?P<minor>[a-z]+)
+        serialize = {major}.{minor}
+
+        [bumpversion:part:minor]
+        values = 
+            alpha
+            beta
+            stable
+        """).strip())
+
+    main(['minor', '--verbose'])
+
+    assert '1.beta' == tmpdir.join("values.txt").read()
+
+    main(['major', '--verbose'])
+
+    assert '2.alpha' == tmpdir.join("values.txt").read()
+
+    with pytest.raises(ValueError):
+        main(['minor', '--verbose'])
+        main(['minor', '--verbose'])
+        main(['minor', '--verbose'])
+
+def test_bump_date_part(tmpdir, capsys):
+    tmpdir.join("date.txt").write("1.20150101090000")
+    tmpdir.chdir()
+
+    tmpdir.join(".bumpversion.cfg").write(dedent("""
+        [bumpversion]
+        files = date.txt
+        current_version = 1.20150101090000
+        parse = (?P<major>\d+)\.(?P<minor>[0-9]+)
+        serialize = {major}.{minor}
+
+        [bumpversion:part:minor]
+        function = date
+        """).strip())
+
+    main(['minor', '--verbose'])
+
+    new_version = tmpdir.join("date.txt").read()
+
+    major, minor = new_version.split('.')
+
+    assert major == '1'
+    assert datetime.strptime(minor, '%Y%m%d%H%M%S') > datetime.strptime('20150101090000', '%Y%m%d%H%M%S')
 
 def test_optional_value_from_documentation(tmpdir):
 

--- a/tests/test_version_part.py
+++ b/tests/test_version_part.py
@@ -2,13 +2,9 @@ import pytest
 
 from bumpversion.version_part import *
 
-@pytest.fixture(params=[None, (('0', '1', '2'),), (('0', '3'),)])
+@pytest.fixture(params=[{}, {'values':('0', '1', '2')}, {'values':('0', '3')}])
 def confvpc(request):
-    if request.param is None:
-        return NumericVersionPartConfiguration()
-    else:
-        return ConfiguredVersionPartConfiguration(*request.param)
-
+    return PartConfiguration(**request.param)
 
 # VersionPart
 


### PR DESCRIPTION
This set of commits extracts the `numeric` and `values` configuration options as classes that are activated through the `function` configuration key.

I also added a `date` function for date-based version parts.

The documentations has been updated accordingly
