### PR TITLE
Fix documentation example with 'optional_value'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,7 +207,7 @@ The following options are valid inside a part configuration:
 
     [bumpversion]
     current_version = 1.alpha
-    parse = (?P<num>\d+)\.(?P<release>.*)
+    parse = (?P<num>\d+)(\.(?P<release>.*))?
     serialize =
       {num}.{release}
       {num}


### PR DESCRIPTION
Fixed regex pattern in documentation for "optional_value".
