### PR TITLE
Issue 135

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -72,7 +72,7 @@ class BaseVCS(object):
         f.write(message.encode('utf-8'))
         f.close()
         subprocess.check_output(cls._COMMIT_COMMAND + [f.name], env=dict(
-            list(os.environ.items()) + [(b'HGENCODING', b'utf-8')]
+            list(os.environ.items()) + [(str('HGENCODING'), str('utf-8'))]
         ))
         os.unlink(f.name)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,7 +21,7 @@ from bumpversion import main, DESCRIPTION, WorkingDirectoryIsDirtyException, \
     split_args_in_optional_and_positional
 
 SUBPROCESS_ENV = dict(
-    list(environ.items()) + [(b'HGENCODING', b'utf-8')]
+    list(environ.items()) + [(str('HGENCODING'), str('utf-8'))]
 )
 
 call = partial(subprocess.call, env=SUBPROCESS_ENV)


### PR DESCRIPTION
Fixes #135 "TypeError: environment can have only strings" by using `str()` instead of `b''` for preparing environment settings.  Tested to make sure it works in both Python 2.7 and Python 3.4 on Windows.