### PR TITLE
Fix Travis py32 environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
   - git config --list
   - echo -e '[ui]\nusername = Testing Mercurial on Travis CI <bumpversion-test-hg@travis.ci>' > ~/.hgrc
   - hg --version
-  - pip install --upgrade pytest tox
+  - travis_retry pip install "virtualenv<14.0.0" pytest tox
 
 script:
   - tox -e $TOX_ENV


### PR DESCRIPTION
Virtualenv 14 does not support Python 3.2 (and is installed by default now in Travis, see https://github.com/travis-ci/travis-ci/issues/5485).  So force Travis to use an older version of virtualenv so that tests pass in py32 environment.

This is causing several PRs from the last few months to fail.
