### PR TITLE
Set UTF-8 stdout under C locale for Python <= 3.6

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -32,6 +32,8 @@ from bumpversion.version_part import VersionPart, NumericVersionPartConfiguratio
 
 if sys.version_info[0] == 2:
     sys.stdout = codecs.getwriter('utf-8')(sys.stdout)
+elif sys.version_info[0] == 3 and sys.version_info[1] <= 6:
+    sys.stdout = codecs.getwriter('utf-8')(sys.stdout.buffer, 'strict')
 
 __VERSION__ = '0.5.4-dev'
 


### PR DESCRIPTION
```
# locale
LANG=
LC_CTYPE="C"
LC_COLLATE="C"
LC_TIME="C"
LC_NUMERIC="C"
LC_MONETARY="C"
LC_MESSAGES="C"
LC_ALL=

# bumpversion-3.6 --help
Traceback (most recent call last):
  File "/usr/local/bin/bumpversion-3.6", line 11, in <module>
    load_entry_point('bumpversion==0.5.3', 'console_scripts', 'bumpversion')()
  File "/usr/local/lib/python3.6/site-packages/bumpversion/__init__.py", line 879, in main
    args = parser3.parse_args(remaining_argv + positionals)
  File "/usr/local/lib/python3.6/argparse.py", line 1734, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/usr/local/lib/python3.6/argparse.py", line 1766, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/usr/local/lib/python3.6/argparse.py", line 1972, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/usr/local/lib/python3.6/argparse.py", line 1912, in consume_optional
    take_action(action, args, option_string)
  File "/usr/local/lib/python3.6/argparse.py", line 1840, in take_action
    action(self, namespace, argument_values, option_string)
  File "/usr/local/lib/python3.6/argparse.py", line 1024, in __call__
    parser.print_help()
  File "/usr/local/lib/python3.6/argparse.py", line 2366, in print_help
    self._print_message(self.format_help(), file)
  File "/usr/local/lib/python3.6/argparse.py", line 2372, in _print_message
    file.write(message)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2192' in position 2393: ordinal not in range(128)
```
Python 3.7 is not affected.
https://www.python.org/dev/peps/pep-0540/
