### PR TITLE
Support files with encoding other than UTF-8.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,12 @@ General configuration is grouped in a ``[bumpversion]`` section.
   Also available as ``--message`` (e.g.: ``bumpversion --message
   '[{now:%Y-%m-%d}] Jenkins Build {$BUILD_NUMBER}: {new_version}' patch``)
 
+``encoding =``
+  **default:** ``utf-8``
+
+  The encoding of the files to modify, unless overridden for a specific
+  file. This can be any encoding supported by Python's ``codecs`` module.
+
 
 Part specific configuration
 ---------------------------
@@ -303,6 +309,12 @@ File specific configuration
 
   Can be multiple lines, templated using `Python Format String Syntax
   <http://docs.python.org/2/library/string.html#format-string-syntax>`_.
+
+``encoding =``
+  **default:** ``utf-8``
+
+  The encoding of the file. This can be any encoding supported by 
+  Python's ``codecs`` module.
 
 Options
 =======

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,7 @@ optional arguments:
                         {current_version})
   --replace REPLACE     Template for complete string to replace (default:
                         {new_version})
+  --encoding ENCODING   File encoding (default: utf-8)
   --current-version VERSION
                         Version that needs to be updated (default: None)
   --dry-run, -n         Don't write any files, just pretend. (default: False)
@@ -213,6 +214,14 @@ def test_simple_replacement_in_utf8_file(tmpdir):
     main(shlex_split("patch --current-version 1.3.0 --new-version 1.3.1 VERSION"))
     out = tmpdir.join("VERSION").read('rb')
     assert "'Kr\\xc3\\xb6t1.3.1'" in repr(out)
+
+
+def test_simple_replacement_in_utf16le_file(tmpdir):
+    tmpdir.join("VERSION").write("Kröt1.3.0".encode('utf-16le'), 'wb')
+    tmpdir.chdir()
+    main(shlex_split("patch --encoding utf-16le --current-version 1.3.0 --new-version 1.3.1 VERSION"))
+    out = tmpdir.join("VERSION").read('rb')
+    assert "'K\\x00r\\x00\\xf6\\x00t\\x001\\x00.\\x003\\x00.\\x001\\x00'" in repr(out)
 
 
 def test_config_file(tmpdir):


### PR DESCRIPTION
This allows bumpversion to be used with files that are not encoded in a way compatible with UTF-8. My particular use case is Visual C++ resource scripts, which are, unfortunately, in UTF-16LE encoding.

Tests pass with Python 2.7.15, and fail weirdly with 3.6, but not due to this change.