### PR TITLE
Enhance missing VCS command detection (errno 13)

### DIFF
--- a/bumpversion/__init__.py
+++ b/bumpversion/__init__.py
@@ -88,6 +88,9 @@ class BaseVCS(object):
             if e.errno == 2:
                 # mercurial is not installed then, ok.
                 return False
+            elif e.errno == 13:
+                # Permission denied
+                return False
             raise
 
 


### PR DESCRIPTION
If a given command/tools is not executable or blocked from execution by a LSM
(SELinux/AppArmor) for example, then consider that VCS to be unavailable.

This change prevents the following error when running 'bumpversion --help'

    OSError: [Error 13] Permission denied