### PR TITLE
Declare `bumpversion` as unmaintained

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. DANGER::
    ⚠️ ``bumpversion`` is **no longer maintained**.
 
-   You should **switch to `bump-my-version <https://github.com/callowayproject/bump-my-version>`_ **.
+   You should **switch to** `bump-my-version <https://github.com/callowayproject/bump-my-version>`_.
 
 ===========
 bumpversion

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,7 @@
-**⚠️ Current status of this project**
+.. DANGER::
+   ⚠️ ``bumpversion`` is **no longer maintained**.
 
-* 🎬If you want to start **using bumpversion**, you're best advised to **install one of the maintained forks**, e.g. ➡ `@c4urself's bump2version <https://github.com/c4urself/bump2version/#installation>`_.
-* 🔨If you want to **help maintain** bumpversion, there's an `ongoing discussion about merging the fork back to the original project as well as forming a group of maintainers <https://github.com/c4urself/bump2version/issues/86>`_ to ensure a long-term future for this project. Please contribute.
-
------
+   You should **switch to `bump-my-version <https://github.com/callowayproject/bump-my-version>`_ **.
 
 ===========
 bumpversion


### PR DESCRIPTION
Both `bumpversion` and `bump2version` are no longer maintained.

This PR redirects users to [`bump-my-version`](https://github.com/callowayproject/bump-my-version).

Fixes:
- https://github.com/peritus/bumpversion/pull/210
- https://github.com/peritus/bumpversion/issues/173
- https://github.com/peritus/bumpversion/issues/169
- https://github.com/c4urself/bump2version/issues/268